### PR TITLE
fix(btls-sys): skip nonexistent link search directories

### DIFF
--- a/btls-sys/build/main.rs
+++ b/btls-sys/build/main.rs
@@ -710,7 +710,9 @@ fn emit_link_directives(config: &Config) {
             .map(|s| dir.join(s))
             .filter(|d| d.exists())
             .unwrap_or(dir);
-        println!("cargo:rustc-link-search=native={}", dir.display());
+        if dir.is_dir() {
+            println!("cargo:rustc-link-search=native={}", dir.display());
+        }
     }
 
     if let Some(cpp_lib) = get_cpp_runtime_lib(config) {


### PR DESCRIPTION
## Summary

  Only emit `cargo:rustc-link-search` directives for directories that actually exist.

  The BoringSSL build script currently emits several candidate library search paths. Depending on the generated CMake layout, directories such as `build/lib` and `build/crypto` may not exist because `libcrypto.a` and `libssl.a` are placed directly under `build/`.

  These nonexistent paths are still passed to the linker as `-L` arguments.

  ## Motivation

  [Rust 1.97 reports linker output by default](https://github.com/rust-lang/rust/pull/153968), making the existing invalid search paths visible:

  ```text
  warning: linker stderr: unable to open library directory '.../build/lib': FileNotFound
  warning: unable to open library directory '.../build/crypto': FileNotFound

  This is reproducible when cross-compiling with cargo-zigbuild. It is not specific to Zig: any linker that reports nonexistent library
  search directories may expose the same issue.

  ## Changes

  Check each candidate path with Path::is_dir() before emitting its cargo:rustc-link-search directive.

  This removes invalid linker arguments without changing the selected libraries or the existing platform-specific directory resolution.

  ## Verification

  - Ran cargo test -p btls-sys
  - Cross-compiled the mk_certs example for x86_64-unknown-linux-gnu
  - Confirmed that the nonexistent library directory warnings are no longer emitted